### PR TITLE
Discontinue Foundation for Public Code stewardship

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Add the template files:
 ## Maintenance
 
 This repository is a collaboration between the [Agency of Digital Government](https://github.com/diggsweden) and [OS2](https://github.com/OS2offdig).
-It is in stewardship with the [Foundation for Public Code](https://github.com/publiccodenet).
-The Foundation for Public Code has committed to make sure that its maintainers are available to review contributions with an aim to provide feedback within two business days.
 
 ## License
 


### PR DESCRIPTION
As stated in email:

* https://lists.publiccode.net/hyperkitty/hyperkitty/list/templates@lists.publiccode.net/thread/WZIVWT4M7CAQOJXULRZRA3WH7NKG3JEK/

The  Foundation for Public Code will be winding down the office in Europe and will no longer be able to steward the template codebase to the level which we aspire.

See also:

* https://blog.publiccode.net/news/2024/02/28/changes-at-the-europe-office.html